### PR TITLE
modified launch file to correspond to gazebo

### DIFF
--- a/cirkit_unit03_apps/launch/robot/autorun.launch
+++ b/cirkit_unit03_apps/launch/robot/autorun.launch
@@ -10,6 +10,6 @@
 
   <include file="$(find cirkit_unit03_control)/launch/urg_laser_filter.launch" />
 
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find cirkit_unit03_viz)/rviz/gazebo/autorun.rviz" required="true" />
- 
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find cirkit_unit03_viz)/rviz/robot/autorun.rviz" required="true" />
+
 </launch>

--- a/cirkit_unit03_apps/launch/robot/autorun.launch
+++ b/cirkit_unit03_apps/launch/robot/autorun.launch
@@ -10,6 +10,6 @@
 
   <include file="$(find cirkit_unit03_control)/launch/urg_laser_filter.launch" />
 
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find cirkit_unit03_viz)/rviz/robot/autorun.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find cirkit_unit03_viz)/rviz/robot/autorun3.rviz" required="true" />
 
 </launch>

--- a/cirkit_unit03_apps/launch/robot/autorun.launch
+++ b/cirkit_unit03_apps/launch/robot/autorun.launch
@@ -1,6 +1,15 @@
 <launch>
+  <!-- Bringup robot driver and sensor drivers-->
   <include file="$(find cirkit_unit03_bringup)/launch/cirkit_unit03_bringup.launch"/>
+
   <include file="$(find cirkit_unit03_move_base)/launch/move_base.launch"/>
 
-  <!-- <node name="cirkit_unit03_monitor_client" pkg="cirkit_unit03_monitor" type="cirkit_unit03_monitor_client"/> -->
+  <include file="$(find cirkit_unit03_amcl)/launch/amcl_diff.launch" />
+
+  <include file="$(find cirkit_unit03_control)/launch/laserscan_merger.launch" />
+
+  <include file="$(find cirkit_unit03_control)/launch/urg_laser_filter.launch" />
+
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find cirkit_unit03_viz)/rviz/gazebo/autorun.rviz" required="true" />
+ 
 </launch>


### PR DESCRIPTION
https://github.com/CIR-KIT-Unit03/cirkit_unit03_whole_issue/issues/19 に対応したプルリクエストです。
ただし、実機はまだ`ros_control`に対応していないため、そこは従来の`bringup`を呼んでいます。
これを実行するには他のパッケージを対応ブランチにする必要があります。

- https://github.com/CIR-KIT-Unit03/cirkit_unit03_navigation/pull/3
- https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot/pull/13
